### PR TITLE
Created spe fitting functionality for CHECLabPy

### DIFF
--- a/CHECLabPy/core/factory.py
+++ b/CHECLabPy/core/factory.py
@@ -1,5 +1,6 @@
 from inspect import isabstract
 from CHECLabPy.core.base_reducer import WaveformReducer
+from CHECLabPy.core.spectrum_fitter import SpectrumFitter
 
 
 class Factory:
@@ -43,7 +44,7 @@ class Factory:
         return unique
 
     @classmethod
-    def produce(cls, product_name, **kwargs):
+    def produce(cls, product_name, *args, **kwargs):
         factory = cls()
         subclass_dict = dict(zip(factory.subclass_names, factory.subclasses))
 
@@ -54,10 +55,16 @@ class Factory:
                    'for factory.'.format(product_name))
             raise KeyError(msg)
 
-        return product(**kwargs)
+        return product(*args, **kwargs)
 
 
 class WaveformReducerFactory(Factory):
     import CHECLabPy.waveform_reducers
     subclasses = Factory.child_subclasses(WaveformReducer)
+    subclass_names = [c.__name__ for c in subclasses]
+
+
+class SpectrumFitterFactory(Factory):
+    import CHECLabPy.spectrum_fitters
+    subclasses = Factory.child_subclasses(SpectrumFitter)
     subclass_names = [c.__name__ for c in subclasses]

--- a/CHECLabPy/core/io.py
+++ b/CHECLabPy/core/io.py
@@ -635,6 +635,7 @@ class DL1Reader(HDFStoreReader):
         self.store = pd.HDFStore(
             path, mode='r', complevel=9, complib='blosc:blosclz'
         )
+        self.path = path
         self.key = 'data'
         self._monitor = None
 

--- a/CHECLabPy/core/spectrum_fitter.py
+++ b/CHECLabPy/core/spectrum_fitter.py
@@ -274,7 +274,7 @@ class SpectrumFitter:
         self.prepare_params(self.p0, limits, fix)
 
         m0 = iminuit.Minuit(self.minimize_function, **self.p0, **limits, **fix,
-                            print_level=0, pedantic=False, throw_nan=False,
+                            print_level=0, pedantic=False, throw_nan=True,
                             forced_parameters=self.coeff_names)
         m0.migrad()
 

--- a/CHECLabPy/core/spectrum_fitter.py
+++ b/CHECLabPy/core/spectrum_fitter.py
@@ -1,0 +1,361 @@
+from abc import abstractmethod
+import iminuit
+import numpy as np
+from scipy.stats.distributions import poisson
+from scipy.stats import chisquare
+
+
+class SpectrumFitter:
+    def __init__(self, n_illuminations):
+        """
+        Base class for fitters of Single-Photoelectron spectra. Built to
+        flexibly handle any number of illuminations simultaneously.
+
+        Parameters
+        ----------
+        n_illuminations : int
+            Number of illuminations to fit simultaneously
+        """
+        self.hist = None
+        self.edges = None
+        self.between = None
+        self.coeff = None
+        self.p0 = None
+
+        self.nbins = 100
+        self.range = [-10, 100]
+
+        self.coeff_names = []
+        self.multi_coeff = []
+        self.initial = dict()
+        self.limits = dict()
+        self.fix = dict()
+
+        self.n_illuminations = n_illuminations
+
+    @property
+    def fit_x(self):
+        """
+        Default X coordinates for the fit
+
+        Returns
+        -------
+        ndarray
+        """
+        return np.linspace(self.edges[0], self.edges[-1], 10*self.edges.size)
+
+    @property
+    def fit(self):
+        """
+        Curve for the current fit result
+
+        Returns
+        -------
+        ndarray
+        """
+        return self.fit_function(x=self.fit_x, **self.coeff)
+
+    @property
+    def n_coeff(self):
+        """
+        Number of free parameters in the fit
+
+        Returns
+        -------
+        int
+        """
+        return len(self.coeff) - sum(self.fix.values())
+
+    @property
+    def chi2(self):
+        """
+        Chi-squared statistic
+
+        Returns
+        -------
+        float
+        """
+        h = np.hstack(self.hist)
+        f = np.hstack(self.fit_function(x=self.between, **self.coeff))
+        b = h >= 5
+        h = h[b]
+        f = f[b]
+        chi2 = np.sum(np.power(h - f, 2)/f)
+        return chi2
+
+    @property
+    def dof(self):
+        """
+        Degrees of freedom based on the histogram and the number of free
+        parameters
+
+        Returns
+        -------
+        int
+        """
+        h = np.hstack(self.hist)
+        n = h[h >= 5].size
+        m = self.n_coeff
+        dof = n - 1 - m
+        return dof
+
+    @property
+    def reduced_chi2(self):
+        """
+        Reduced Chi-Squared statistic
+
+        Returns
+        -------
+        float
+        """
+        return self.chi2 / self.dof
+
+    @property
+    def p_value(self):
+        """
+        The probability value for the resulting fit of obtaining a spectrum
+        equal to or more extreme than what was actually measured.
+
+        In this context, a high p-value indicates a good fit.
+
+        Returns
+        -------
+        float
+        """
+        h = np.hstack(self.hist)
+        f = np.hstack(self.fit_function(x=self.between, **self.coeff))
+        b = h >= 5
+        h = h[b]
+        f = f[b]
+        return chisquare(h, f, self.n_coeff).pvalue
+
+    def add_parameter(self, name, inital, lower, upper,
+                      fix=False, multi=False):
+        """
+        Add a new parameter for this particular fit function
+
+        Parameters
+        ----------
+        name : str
+            Name of the parameter
+        inital : float
+            Initial value for the parameter
+        lower : float
+            Lower limit for the parameter
+        upper : float
+            Upper limit for the parameter
+        fix : bool
+            Specify if the parameter should be fixed
+        multi : bool
+            Specify if the parameter should be duplicated for additional
+            illuminations
+        """
+        if not multi:
+            self.coeff_names.append(name)
+            self.initial[name] = inital
+            self.limits["limit_" + name] = (lower, upper)
+            self.fix["fix_" + name] = fix
+        else:
+            self.multi_coeff.append(name)
+            for i in range(self.n_illuminations):
+                name_i = name + str(i)
+                self.coeff_names.append(name_i)
+                self.initial[name_i] = inital
+                self.limits["limit_" + name_i] = (lower, upper)
+                self.fix["fix_" + name_i] = fix
+        ds = "minimize_function(" + ", ".join(self.coeff_names) + ")"
+        self.minimize_function.__func__.__doc__ = ds
+
+    def apply(self, *spectrum):
+        """
+        Fit the spectra
+
+        Parameters
+        ----------
+        spectrum : list[ndarray]
+            A list of the spectra to fit. Should have a length equal to the
+            self.n_illuminations.
+        """
+        assert len(spectrum) == self.n_illuminations
+        bins = self.nbins
+        range_ = self.range
+        self.hist = []
+        for i in range(self.n_illuminations):
+            h, e, b = self.get_histogram(spectrum[i], bins, range_)
+            self.hist.append(h)
+            self.edges = e
+            self.between = b
+
+        self._perform_fit()
+
+    @staticmethod
+    def get_histogram(spectrum, bins, range_):
+        """
+        Obtain a histogram for the spectrum.
+
+        Look at `np.histogram` documentation for further info on Parameters.
+
+        Parameters
+        ----------
+        spectrum : ndarray
+        bins
+        range_
+
+        Returns
+        -------
+        hist : ndarray
+            The histogram
+        edges : ndarray
+            Edges of the histogram
+        between : ndarray
+            X values of the middle of each bin
+        """
+        hist, edges = np.histogram(spectrum, bins=bins, range=range_)
+        between = (edges[1:] + edges[:-1]) / 2
+
+        # zero = between[np.argmax(hist)]
+        # spectrum -= zero
+        #
+        # hist, edges = np.histogram(spectrum, bins=bins, range=range_)
+        # between = (edges[1:] + edges[:-1]) / 2
+
+        return hist, edges, between
+
+    def get_histogram_summed(self, spectra, bins, range_):
+        """
+        Get the histogram including the spectra from all the illuminations.
+
+        Look at `np.histogram` documentation for further info on Parameters.
+
+        Parameters
+        ----------
+        spectra : list
+        bins
+        range_
+
+        Returns
+        -------
+        hist : ndarray
+            The histogram
+        edges : ndarray
+            Edges of the histogram
+        between : ndarray
+            X values of the middle of each bin
+        """
+        spectra_stacked = np.hstack(spectra)
+        hist, edge, between = self.get_histogram(spectra_stacked, bins, range_)
+        return hist, edge, between
+
+    def get_fit_summed(self, x, **coeff):
+        """
+        Get the summed fit for all the illuminations.
+
+        Parameters
+        ----------
+        x : ndarray
+            X values for the fit
+        coeff
+            The fit coefficients to apply to the fit function.
+
+        Returns
+        -------
+        ndarray
+        """
+        return np.sum(self.fit_function(x, **coeff), 0)
+
+    def _perform_fit(self):
+        """
+        Run iminuit on the fit function to find the best fit
+        """
+        self.coeff = {}
+        self.p0 = self.initial.copy()
+        limits = self.limits.copy()
+        fix = self.fix.copy()
+        self.prepare_params(self.p0, limits, fix)
+
+        m0 = iminuit.Minuit(self.minimize_function, **self.p0, **limits, **fix,
+                            print_level=0, pedantic=False, throw_nan=False,
+                            forced_parameters=self.coeff_names)
+        m0.migrad()
+
+        self.coeff = m0.values
+
+    def prepare_params(self, p0, limits, fix):
+        """
+        Apply some automation to the contents of initial, limits, and fix
+        dictionaries.
+
+        Parameters
+        ----------
+        p0 : dict
+            Initial values dict
+        limits : dict
+            Dict containing the limits for each parameter
+        fix : dict
+            Dict containing which parameters should be fixed
+        """
+        pass
+
+    def minimize_function(self, *args):
+        """
+        Function which calculates the likelihood to be minimised.
+
+        Parameters
+        ----------
+        args
+            The values to apply to the fit function.
+
+        Returns
+        -------
+        likelihood : float
+        """
+        kwargs = dict(zip(self.coeff_names, args))
+        x = self.between
+        y = self.hist
+        p = self.fit_function(x, **kwargs)
+        like = [-2 * poisson._logpmf(y[i], p[i])
+                for i in range(self.n_illuminations)]
+        like = np.hstack(like)
+        return np.nansum(like)
+
+    def fit_function(self, x, **kwargs):
+        """
+        Function which applies the parameters for each illumination and
+        returns the resulting curves.
+
+        Parameters
+        ----------
+        x : ndarray
+            X values
+        kwargs
+            The values to apply to the fit function
+
+        Returns
+        -------
+
+        """
+        p = []
+        for i in range(self.n_illuminations):
+            for coeff in self.multi_coeff:
+                kwargs[coeff] = kwargs[coeff + str(i)]
+            p.append(self._fit(x, **kwargs))
+        return p
+
+    @staticmethod
+    @abstractmethod
+    def _fit(x, **kwargs):
+        """
+        Define the low-level function to be used in the fit
+
+        Parameters
+        ----------
+        x : ndarray
+            X values
+        kwargs
+            The values to apply to the fit function
+
+        Returns
+        -------
+        ndarray
+        """
+        pass

--- a/CHECLabPy/plotting/spe.py
+++ b/CHECLabPy/plotting/spe.py
@@ -1,0 +1,54 @@
+import numpy as np
+from matplotlib import pyplot as plt
+from CHECLabPy.plotting.setup import Plotter
+
+
+class SpectrumFitPlotter(Plotter):
+    def __init__(self, talk=False):
+        super().__init__(talk=talk)
+        self.fig = plt.figure(figsize=(13, 6))
+        self.ax = plt.subplot2grid((3, 2), (0, 0), rowspan=3)
+        self.ax_t = plt.subplot2grid((3, 2), (0, 1), rowspan=3)
+
+    def plot(self, hist, edges, between, fit_x, fit, initial, coeff,
+             coeff_initial, fitter_name, n_illuminations):
+
+        self.ax.hist(between, bins=edges, weights=hist, histtype='step',
+                     label="Hist")
+        self.ax.plot(fit_x, fit, label="Fit")
+        self.ax.plot(fit_x, initial, label="Initial")
+        self.ax.legend(loc=1, frameon=True, fancybox=True, framealpha=0.7)
+        self.ax_t.axis('off')
+        columns = ['Initial', 'Fit']
+        rows = list(coeff.keys())
+        cells = [['%.3g' % coeff_initial[i], '%.3g' % coeff[i]] for i in rows]
+        table = self.ax_t.table(cellText=cells, rowLabels=rows,
+                                colLabels=columns, loc='center')
+        table.set_fontsize(6)
+        title = "{}, {} Illuminations".format(fitter_name, n_illuminations)
+        self.fig.suptitle(title, x=0.75)
+
+    def plot_from_fitter(self, fitter, charges):
+        fitter.apply(*charges)
+        fitter_name = fitter.__class__.__name__
+        n_illuminations = fitter.n_illuminations
+        x = np.linspace(fitter.range[0], fitter.range[1], 1000)
+        hist, edges, between = fitter.get_histogram_summed(
+            charges, fitter.nbins, fitter.range
+        )
+        coeff = fitter.coeff.copy()
+        coeffl = fitter.coeff_names.copy()
+        coeff_initial = fitter.p0.copy()
+        fit = fitter.get_fit_summed(x, **coeff)
+        initial = fitter.get_fit_summed(x, **coeff_initial)
+
+        coeff['chi2'] = fitter.chi2
+        coeff['rchi2'] = fitter.reduced_chi2
+        coeff['p_value'] = fitter.p_value
+        fitter.coeff = coeff_initial
+        coeff_initial['chi2'] = fitter.chi2
+        coeff_initial['rchi2'] = fitter.reduced_chi2
+        coeff_initial['p_value'] = fitter.p_value
+
+        self.plot(hist, edges, between, x, fit, initial, coeff, coeff_initial,
+                  fitter_name, n_illuminations)

--- a/CHECLabPy/plotting/spe.py
+++ b/CHECLabPy/plotting/spe.py
@@ -52,3 +52,31 @@ class SpectrumFitPlotter(Plotter):
 
         self.plot(hist, edges, between, x, fit, initial, coeff, coeff_initial,
                   fitter_name, n_illuminations)
+
+    def plot_from_df_pixel(self, df_coeff, df_inital, df_array, meta, pixel):
+        fitter_name = meta['fitter']
+        n_illuminations = meta['n_illuminations']
+        hist = df_array.loc[pixel, 'hist']
+        edges = df_array.loc[pixel, 'edges']
+        between = df_array.loc[pixel, 'between']
+        fit_x = df_array.loc[pixel, 'fit_x']
+        fit = df_array.loc[pixel, 'fit']
+        initial = df_array.loc[pixel, 'initial']
+        coeff = df_coeff.loc[pixel].to_dict()
+        coeff_initial = df_inital.loc[pixel].to_dict()
+        self.plot(hist, edges, between, fit_x, fit, initial, coeff,
+                  coeff_initial, fitter_name, n_illuminations)
+
+    def plot_from_df_camera(self, df_coeff, df_inital, df_array, meta):
+        fitter_name = meta['fitter']
+        n_illuminations = meta['n_illuminations']
+        hist = df_array.loc[0, 'hist']
+        edges = df_array.loc[0, 'edges']
+        between = df_array.loc[0, 'between']
+        fit_x = df_array.loc[0, 'fit_x']
+        fit = df_array.loc[0, 'fit']
+        initial = df_array.loc[0, 'initial']
+        coeff = df_coeff.loc[0].to_dict()
+        coeff_initial = df_inital.loc[0].to_dict()
+        self.plot(hist, edges, between, fit_x, fit, initial, coeff,
+                  coeff_initial, fitter_name, n_illuminations)

--- a/CHECLabPy/spectrum_fitters/__init__.py
+++ b/CHECLabPy/spectrum_fitters/__init__.py
@@ -1,0 +1,18 @@
+"""
+Module for containing all the charge spectrum fitters
+"""
+
+__all__ = []
+
+import pkgutil
+import inspect
+
+for loader, name, is_pkg in pkgutil.walk_packages(__path__):
+    module = loader.find_module(name).load_module(name)
+
+    for name, value in inspect.getmembers(module):
+        if name.startswith('__'):
+            continue
+
+        globals()[name] = value
+        __all__.append(name)

--- a/CHECLabPy/spectrum_fitters/gentile.py
+++ b/CHECLabPy/spectrum_fitters/gentile.py
@@ -19,7 +19,7 @@ class GentileFitter(SpectrumFitter):
         super().__init__(n_illuminations)
 
         self.nbins = 100
-        self.range = [-50, 150]
+        self.range = [-40, 150]
 
         self.add_parameter("norm", None, 0, 100000, fix=True, multi=True)
         self.add_parameter("eped", 0, -10, 10)
@@ -27,8 +27,8 @@ class GentileFitter(SpectrumFitter):
         self.add_parameter("spe", 38, 15, 40)
         self.add_parameter("spe_sigma", 2, 2, 20)
         self.add_parameter("lambda_", 0.7, 0.1, 3, multi=True)
-        self.add_parameter("opct", 0.4, 0, 0.8)
-        self.add_parameter("pap", 0.09, 0, 0.8)
+        self.add_parameter("opct", 0.4, 0.01, 0.8)
+        self.add_parameter("pap", 0.09, 0.01, 0.8)
         self.add_parameter("dap1", 0.5, 0, 0.8)
         self.add_parameter("dap2", 0.5, 0, 0.8)
 

--- a/CHECLabPy/spectrum_fitters/gentile.py
+++ b/CHECLabPy/spectrum_fitters/gentile.py
@@ -1,0 +1,247 @@
+import numpy as np
+from math import factorial
+from scipy.special import binom
+from numba import jit
+from CHECLabPy.core.spectrum_fitter import SpectrumFitter
+
+
+class GentileFitter(SpectrumFitter):
+    def __init__(self, n_illuminations):
+        """
+        SpectrumFitter which uses the SiPM fitting formula from Gentile 2010
+        http://adsabs.harvard.edu/abs/2010arXiv1006.3263G
+
+        Parameters
+        ----------
+        n_illuminations : int
+            Number of illuminations to fit simultaneously
+        """
+        super().__init__(n_illuminations)
+
+        self.nbins = 100
+        self.range = [-50, 150]
+
+        self.add_parameter("norm", None, 0, 100000, fix=True, multi=True)
+        self.add_parameter("eped", 0, -10, 10)
+        self.add_parameter("eped_sigma", 10, 2, 20)
+        self.add_parameter("spe", 38, 15, 40)
+        self.add_parameter("spe_sigma", 2, 2, 20)
+        self.add_parameter("lambda_", 0.7, 0.1, 3, multi=True)
+        self.add_parameter("opct", 0.4, 0, 0.8)
+        self.add_parameter("pap", 0.09, 0, 0.8)
+        self.add_parameter("dap1", 0.5, 0, 0.8)
+        self.add_parameter("dap2", 0.5, 0, 0.8)
+
+    def prepare_params(self, p0, limits, fix):
+        for i in range(self.n_illuminations):
+            norm = 'norm{}'.format(i)
+            if p0[norm] is None:
+                p0[norm] = np.trapz(self.hist[i], self.between)
+
+    @staticmethod
+    def _fit(x, **kwargs):
+        return sipm_spe_fit(x, **kwargs)
+
+
+C = np.sqrt(2.0 * np.pi)
+FACTORIAL = np.array([factorial(i) for i in range(15)])
+FACTORIAL_0 = FACTORIAL[0]
+NPEAKS = 11
+N = np.arange(NPEAKS)[:, None]
+J = np.arange(NPEAKS)[None, :]
+K = np.arange(1, NPEAKS)[:, None]
+FACTORIAL_J_INV = 1 / FACTORIAL[J]
+BINOM = binom(N - 1, J - 1)
+
+
+@jit(nopython=True)
+def _normal_pdf(x, mean=0, std_deviation=1):
+    """
+    Evaluate the normal probability density function. Faster than
+    `scipy.norm.pdf` as it does not check the inputs.
+
+    Parameters
+    ----------
+    x : ndarray
+        The normal probability function will be evaluated
+    mean : float or ndarray
+    std_deviation : float or array_like
+
+    Returns
+    -------
+    ndarray
+    """
+    u = (x - mean) / std_deviation
+    return np.exp(-0.5 * u ** 2) / (C * std_deviation)
+
+
+@jit(nopython=True)
+def _poisson_pmf_j(mu):
+    """
+    Evaluate the poisson pmf for a fixed k=J events
+
+    Parameters
+    ----------
+    mu : Average number of events
+
+    Returns
+    -------
+    ndarray
+    """
+    return mu ** J * np.exp(-mu) * FACTORIAL_J_INV
+
+
+@jit(nopython=True)
+def pedestal_signal(x, norm, eped, eped_sigma, lambda_):
+    """
+    Obtain the signal provided by the pedestal in the pulse spectrum.
+
+    Parameters
+    ----------
+    x : ndarray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    lambda_ : float
+        Poisson mean
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the signal provided by the pedestal.
+    """
+    p_ped = np.exp(-lambda_)  # Poisson PMF for k = 0, mu = lambda_
+    signal = norm * p_ped * _normal_pdf(x, eped, eped_sigma)
+    return signal
+
+
+@jit
+def pe_signal(k, x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct,
+              pap, dap1, dap2):
+    """
+    Obtain the signal provided by photoelectrons in the pulse spectrum.
+
+    Parameters
+    ----------
+    k : int or ndarray
+        The NPEs to evaluate. A list of NPEs can be passed here, provided it
+        is broadcast as [:, None], and the x input is broadcast as [None, :],
+        the return value will then be a shape [k.size, x.size].
+        k must be greater than or equal to 1.
+    x : ndarray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    spe : float
+        Signal produced by 1 photo-electron
+    spe_sigma : float
+        Spread in the number of photo-electrons incident on the MAPMT
+    lambda_ : float
+        Poisson mean (illumination in p.e.)
+    opct : float
+        Optical crosstalk probability
+    pap : float
+        Afterpulse probability
+    dap1 : float
+        The first distance of the after-pulse Gaussians from the main peaks
+    dap2 : float
+        The second distance of the after-pulse Gaussians from the main peaks
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the signal provided by the photoelectrons. If k is an
+        integer, this will have same shape as x. If k is an array,
+        and k and x are broadcase correctly, this will have
+        shape [k.size, x.size].
+
+    """
+    # Obtain poisson distribution
+    pj = _poisson_pmf_j(lambda_)
+    pct = np.sum(pj * np.power(1-opct, J) * np.power(opct, N - J) * BINOM, 1)
+
+    sap = spe_sigma
+    d1ap = dap1
+    d2ap = dap2  # 2*dap
+    # if d1ap > d2ap:
+    #     d1ap = 2*dap
+    #     d2ap = dap
+
+    # pap_ap1 = pct * pap
+    # pap_ap2 = pct * pap ** 2
+    # pap_noap = pct - pap_ap1 - pap_ap2
+
+    papk = np.power(1 - pap, N[:, 0])
+    p0ap = pct * papk
+    pap1 = pct * (1-papk) * papk
+    pap2 = pct * (1-papk) * (1-papk)
+
+    pe_sigma = np.sqrt(k * spe_sigma ** 2 + eped_sigma ** 2)
+    ap_sigma = np.sqrt(k * sap ** 2 + eped_sigma ** 2)
+
+    signal = p0ap[k] * _normal_pdf(x, eped + k * spe, pe_sigma)
+    signal += pap1[k] * _normal_pdf(x, eped + k * spe * (1.0-d1ap), ap_sigma)
+    signal += pap2[k] * _normal_pdf(x, eped + k * spe * (1.0-d2ap), ap_sigma)
+
+    signal *= norm
+
+    return signal
+
+
+def sipm_spe_fit(x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct,
+                 pap, dap1, dap2, **kwargs):
+    """
+    Fit for the SPE spectrum of a MAPM
+
+    Parameters
+    ----------
+    x : 1darray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    spe : float
+        Signal produced by 1 photo-electron
+    spe_sigma : float
+        Spread in the number of photo-electrons incident on the MAPMT
+    lambda_ : float
+        Poisson mean (illumination in p.e.)
+    opct : float
+        Optical crosstalk probability
+    pap : float
+        Afterpulse probability
+    dap1 : float
+        The first distance of the after-pulse Gaussians from the main peaks
+    dap2 : float
+        The second distance of the after-pulse Gaussians from the main peaks
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the total signal.
+    """
+
+    # Obtain pedestal signal
+    params = [norm, eped, eped_sigma, lambda_]
+    ped_s = pedestal_signal(x, *params)
+
+    # Obtain pe signal
+
+    params = [norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct, pap,
+              dap1, dap2]
+    pe_s = pe_signal(K, x[None, :], *params).sum(0)
+
+    signal = ped_s + pe_s
+
+    return signal

--- a/scripts/extract_spe.py
+++ b/scripts/extract_spe.py
@@ -1,0 +1,369 @@
+"""
+Executable for extracting the Single-Photoelectron spectrum and fit from dl1
+files
+"""
+import argparse
+import os
+from argparse import ArgumentDefaultsHelpFormatter as Formatter
+from functools import partial
+import numpy as np
+import pandas as pd
+from tqdm import trange
+from multiprocessing import Pool, Manager
+from CHECLabPy.core.io import DL1Reader
+from CHECLabPy.core.factory import SpectrumFitterFactory
+
+
+class SpectrumFitProcessor:
+    def __init__(self, fitter, *readers):
+        """
+        Processes the spectrum to obtain the fit parameters for each pixel,
+        utilising all cpu cores via the multiprocessing package.
+
+        Parameters
+        ----------
+        fitter : `CHECLabPy.core.spectrum_fitter.SpectrumFitter`
+        readers : list[`CHECLabPy.core.io.DL1Reader`]
+            The readers for each SPE illumination
+        """
+        self.fitter = fitter
+        self.n_readers = len(readers)
+        self.n_pixels = readers[0].n_pixels
+        self.pixels = []
+        self.charges = []
+        for reader in readers:
+            pixel, charge = reader.select_columns(['pixel', 'charge'])
+            self.pixels.append(pixel.values)
+            self.charges.append(charge.values)
+
+        self.x = np.linspace(self.fitter.range[0], self.fitter.range[1], 1000)
+        self.f_hist = partial(
+            self.fitter.get_histogram_summed,
+            bins=self.fitter.nbins,
+            range_=self.fitter.range
+        )
+        self.f_fit = partial(self.fitter.get_fit_summed, x=self.x)
+
+        manager = Manager()
+        self.array = manager.dict()
+        self.coeff = manager.dict()
+        self.initial = manager.dict()
+
+    def apply_pixel(self, pixel):
+        """
+        Obtain the fit parameters for a pixel
+
+        Parameters
+        ----------
+        pixel : int
+        """
+        pixel_charges = self.get_pixel_charges(pixel)
+        self.fitter.apply(*pixel_charges)
+
+        hist, edges, between = self.f_hist(pixel_charges)
+        fit = self.f_fit(**self.fitter.coeff)
+        initial = self.f_fit(**self.fitter.p0)
+        self.array[pixel] = dict(
+            pixel=pixel,
+            hist=hist,
+            edges=edges,
+            between=between,
+            fit_x=self.x,
+            fit=fit,
+            initial=initial
+        )
+
+        coeff = self.fitter.coeff.copy()
+        coeff['pixel'] = pixel
+        coeff['chi2'] = self.fitter.chi2
+        coeff['rchi2'] = self.fitter.reduced_chi2
+        coeff['p_value'] = self.fitter.p_value
+        self.coeff[pixel] = coeff
+
+        initial = self.fitter.p0.copy()
+        initial['pixel'] = pixel
+        initial['chi2'] = np.nan
+        initial['rchi2'] = np.nan
+        initial['p_value'] = np.nan
+        self.initial[pixel] = initial
+
+    def get_pixel_charges(self, pixel):
+        """
+        Get the charges for every illumination for a single pixel.
+
+        Parameters
+        ----------
+        pixel : int
+
+        Returns
+        -------
+        list[ndarray]
+        """
+        return [self.get_pixel_charge(r, pixel) for r in range(self.n_readers)]
+
+    def get_pixel_charge(self, reader_i, pixel):
+        """
+        Get the charge values of an illumination for a single pixel.
+
+        Parameters
+        ----------
+        reader_i : int
+        pixel : int
+
+        Returns
+        -------
+        ndarray
+        """
+        return self.charges[reader_i][self.pixels[reader_i] == pixel]
+
+    def process(self):
+        """
+        Traditional process where each pixel is fitted in series
+        """
+        for i in trange(self.n_pixels):
+            self.apply_pixel(i)
+
+    def multiprocess(self):
+        """
+        Multi-process, where every cpu core is utilised to process pixels in
+        parallel for a faster result
+        """
+        with Pool() as pool:
+            pool.map(self.apply_pixel, trange(self.n_pixels))
+
+    def get_df_result(self):
+        """
+        Extract of the fit results per pixel as DataFrames
+
+        Returns
+        -------
+        df_coeff : `pd.DataFrame`
+            DataFrame containing the fit coefficients for each pixel
+        df_initial : `pd.DataFrame`
+            DataFrame containing the initial fit coefficients for each pixel
+        df_array : `pd.DataFrame`
+            DataFrame containing the arrays of the histograms and fits for
+            each pixel
+        """
+        df_coeff = pd.DataFrame(list(self.coeff.values()))
+        df_initial = pd.DataFrame(list(self.initial.values()))
+        df_array = pd.DataFrame(list(self.array.values()))
+        df_coeff = df_coeff.set_index('pixel', drop=False).sort_index()
+        df_initial = df_initial.set_index('pixel', drop=False).sort_index()
+        df_array = df_array.set_index('pixel', drop=False).sort_index()
+        return df_coeff, df_initial, df_array
+
+    def get_df_result_camera(self):
+        """
+        Calculate and extract the fit results for the entire camera
+
+        Returns
+        -------
+        df_coeff : `pd.DataFrame`
+            DataFrame containing the fit coefficients for all pixels
+        df_initial : `pd.DataFrame`
+            DataFrame containing the initial fit coefficients for all pixels
+        df_array : `pd.DataFrame`
+            DataFrame containing the arrays of the histograms and fits for
+            all pixels
+        """
+        self.fitter.apply(*self.charges)
+        hist, edges, between = self.f_hist(self.charges)
+        fit = self.f_fit(**self.fitter.coeff)
+        initial = self.f_fit(**self.fitter.p0)
+        array = dict(
+            hist=hist,
+            edges=edges,
+            between=between,
+            fit_x=self.x,
+            fit=fit,
+            initial=initial
+        )
+
+        coeff = self.fitter.coeff.copy()
+        coeff['chi2'] = self.fitter.chi2
+        coeff['rchi2'] = self.fitter.reduced_chi2
+        coeff['p_value'] = self.fitter.p_value
+
+        initial = self.fitter.p0.copy()
+        initial['chi2'] = np.nan
+        initial['rchi2'] = np.nan
+        initial['p_value'] = np.nan
+
+        df_coeff = pd.DataFrame(list(coeff.values()))
+        df_initial = pd.DataFrame(list(initial.values()))
+        df_array = pd.DataFrame(list(array.values()))
+        return df_coeff, df_initial, df_array
+
+
+def main():
+    description = ('Extract and fit the Single-Photoelectron spectrum '
+                   'from N dl1 files simultaneously')
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=Formatter)
+    parser.add_argument('-f', '--files', dest='input_paths', nargs='+',
+                        help='path to the input dl1 run files')
+    parser.add_argument('-o', '--output', dest='output_path', action='store',
+                        help='path to store the output HDF5 file '
+                             '(OPTIONAL, will be automatically set if '
+                             'not specified)')
+    parser.add_argument('-s', '--fitter', dest='fitter', action='store',
+                        default='GentileFitter',
+                        choices=SpectrumFitterFactory.subclass_names,
+                        help='SpectrumFitter to use')
+    args = parser.parse_args()
+
+    input_paths = args.input_paths
+    output_path = args.output_path
+    fitter_str = args.fitter
+
+    readers = [DL1Reader(path) for path in input_paths]
+    kwargs = dict(product_name=fitter_str, n_illuminations=len(readers))
+    fitter = SpectrumFitterFactory.produce(**kwargs)
+
+    fit_processor = SpectrumFitProcessor(fitter, *readers)
+    # fit_processor.process()
+    fit_processor.multiprocess()
+
+    if not output_path:
+        if len(input_paths) == 1:
+            output_path = input_paths[0].replace('_dl1.h5', '_spe.h5')
+        else:
+            output_dir = os.path.dirname(input_paths[0])
+            output_path = os.path.join(output_dir, "spe.h5")
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    print("Created HDFStore file: {}".format(output_path))
+    with pd.HDFStore(output_path) as store:
+        df_coeff, df_initial, df_array = fit_processor.get_df_result()
+        store['coeff_pixel'] = df_coeff
+        store['initial_pixel'] = df_initial
+        store['array_pixel'] = df_array
+
+        df_coeff, df_initial, df_array = fit_processor.get_df_result_camera()
+        store['coeff_camera'] = df_coeff
+        store['initial_camera'] = df_initial
+        store['array_camera'] = df_array
+
+        # TODO: metadata & mapping
+
+    # embed()
+
+    # pixel, charge = reader.select_columns(['pixel', 'charge'])
+    # # df = pd.DataFrame(dict(pixel=pixel, charge=charge))
+    #
+    # groupby = df.groupby('pixel')
+    # n_pixels = reader.n_pixels
+    # desc = "Fitting pixels"
+    # # for pixel, df_group in tqdm(groupby, total=n_pixels, desc=desc):
+    # #     pixel_charge = df_group['charge'].values
+    # #     fitter.apply(pixel_charge)
+    #
+    # for p in trange(n_pixels, desc=desc):
+    #     pixel_charge = charge[pixel == p]
+    #     fitter.apply(pixel_charge)
+    #     # d = fitter.coeff.copy()
+    #     # d['pixel'] = d
+
+
+
+    # plt.plot(fitter.between, fitter.hist[0])
+    # plt.plot(fitter.fit_x, fitter.fit[0])
+    # fitter.coeff = fitter.initial
+    # plt.plot(fitter.fit_x, fitter.fit[0])
+    # plt.show()
+    #
+    # fit_processor(897)
+    # fitter = fit_processor.fitter
+    # fig_fit = plt.figure(figsize=(13, 6))
+    # fig_fit.suptitle("Single Fit")
+    # ax = plt.subplot2grid((3, 2), (0, 0), rowspan=3)
+    # ax_t = plt.subplot2grid((3, 2), (0, 1), rowspan=3)
+    # x = np.linspace(fitter.range[0], fitter.range[1], 1000)
+    # hist = fitter.hist_summed
+    # edges = fitter.edges
+    # between = fitter.between
+    # coeff = fitter.coeff.copy()
+    # coeffl = fitter.coeff_names.copy()
+    # initial = fitter.p0.copy()
+    # fit = fitter.get_fit_summed(x, **coeff)
+    # init = fitter.get_fit_summed(x, **initial)
+    # rc2 = fitter.reduced_chi2
+    # pval = fitter.p_value
+    # ax.hist(between, bins=edges, weights=hist, histtype='step', label="Hist")
+    # ax.plot(x, fit, label="Fit")
+    # ax.plot(x, init, label="Initial")
+    # ax.legend(loc=1, frameon=True, fancybox=True, framealpha=0.7)
+    # ax_t.axis('off')
+    # td = [[initial[i], '%.3f' % coeff[i]] for i in coeffl]
+    # td.append(["", '%.3g' % rc2])
+    # td.append(["", '%.3g' % pval])
+    # tr = coeffl
+    # tr.append("Reduced Chi^2")
+    # tr.append("P-Value")
+    # tc = ['Initial', 'Fit']
+    # table = ax_t.table(cellText=td, rowLabels=tr, colLabels=tc, loc='center')
+    # table.set_fontsize(6)
+    # plt.show()
+
+        # t_cpu = 0
+        # start_time = 0
+        # desc = "Processing events"
+        # for waveforms in tqdm(reader, total=n_events, desc=desc):
+        #     iev = reader.index
+        #
+        #     t_tack = reader.current_tack
+        #     t_cpu_sec = reader.current_cpu_s
+        #     t_cpu_ns = reader.current_cpu_ns
+        #     t_cpu = pd.to_datetime(
+        #         np.int64(t_cpu_sec * 1E9) + np.int64(t_cpu_ns),
+        #         unit='ns'
+        #     )
+        #     fci = reader.first_cell_ids
+        #
+        #     if not start_time:
+        #         start_time = t_cpu
+        #
+        #     waveforms_bs = baseline_subtractor.subtract(waveforms)
+        #     bs = baseline_subtractor.baseline
+        #
+        #     params = reducer.process(waveforms_bs)
+        #
+        #     df_ev = pd.DataFrame(dict(
+        #         iev=iev,
+        #         pixel=pixel_array,
+        #         first_cell_id=fci,
+        #         t_cpu=t_cpu,
+        #         t_tack=t_tack,
+        #         baseline_subtracted=bs,
+        #         **params
+        #     ))
+        #     writer.append_event(df_ev)
+        #
+        # sn_dict = {}
+        # for tm in range(n_modules):
+        #     sn_dict['TM{:02d}_SN'.format(tm)] = reader.get_sn(tm)
+        #
+        # metadata = dict(
+        #     source="CHECLabPy",
+        #     date_generated=pd.datetime.now(),
+        #     input_path=input_path,
+        #     n_events=n_events,
+        #     n_modules=n_modules,
+        #     n_pixels=n_pixels,
+        #     n_samples=n_samples,
+        #     n_cells=n_cells,
+        #     start_time=start_time,
+        #     end_time=t_cpu,
+        #     camera_version=camera_version,
+        #     reducer=reducer.__class__.__name__,
+        #     configuration=config_string,
+        #     **sn_dict
+        # )
+        #
+        # writer.add_metadata(**metadata)
+        # writer.add_mapping(mapping)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/extract_spe.py
+++ b/scripts/extract_spe.py
@@ -34,7 +34,7 @@ class SpectrumFitProcessor:
         self.fitter = fitter
         self.dead_pixels = dead_pixels if dead_pixels is not None else []
         self.n_readers = len(readers)
-        self.n_pixels = 1#readers[0].n_pixels
+        self.n_pixels = readers[0].n_pixels
         self.pixels = []
         self.charges = []
         desc = "Obtaining charge columns from readers"
@@ -202,9 +202,9 @@ class SpectrumFitProcessor:
         initial['rchi2'] = self.fitter.reduced_chi2
         initial['p_value'] = self.fitter.p_value
 
-        df_coeff = pd.DataFrame(list(coeff.values()))
-        df_initial = pd.DataFrame(list(initial.values()))
-        df_array = pd.DataFrame(list(array.values()))
+        df_coeff = pd.DataFrame([coeff])
+        df_initial = pd.DataFrame([initial])
+        df_array = pd.DataFrame([array])
         return df_coeff, df_initial, df_array
 
 

--- a/scripts/plot_spe.py
+++ b/scripts/plot_spe.py
@@ -1,0 +1,114 @@
+"""
+Executable for plotting the extractd fit parameters from extract_spe
+"""
+import argparse
+import os
+from argparse import ArgumentDefaultsHelpFormatter as Formatter
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+import warnings
+from CHECLabPy.plotting.setup import Plotter
+from CHECLabPy.plotting.spe import SpectrumFitPlotter
+from CHECLabPy.plotting.camera import CameraImage
+
+
+class SPECamera:
+    def __init__(self, mapping, output_dir):
+        self.camera = CameraImage.from_mapping(mapping)
+        self.camera.add_colorbar()
+        self.output_dir = output_dir
+
+    def produce(self, df):
+        pixel = df['pixel'].values
+        columns = df.columns
+        d = self.output_dir
+        for c in columns:
+            if c == 'pixel':
+                continue
+            image = df[c].values[pixel]
+            self.camera.image = image
+            self.camera.ax.set_title(c)
+            output_path = os.path.join(d, "camera_{}.pdf".format(c))
+            self.camera.save(output_path)
+
+
+class SPEHist(Plotter):
+    def __init__(self, output_dir):
+        super().__init__()
+        self.output_dir = output_dir
+
+    def produce(self, df):
+        pixel = df['pixel'].values
+        columns = df.columns
+        d = self.output_dir
+        for c in columns:
+            self.fig, self.ax = self.create_figure()
+            if c == 'pixel':
+                continue
+            values = df[c].values[pixel]
+            mean = np.mean(values)
+            std = np.std(values)
+            label = "Mean = {:.3g}, Stddev = {:.3g}".format(mean, std)
+            try:
+                self.ax.hist(values, bins='fd', label=label)
+            except ValueError:
+                self.ax.hist(values, bins='doane', label=label)
+            self.add_legend()
+            self.ax.set_title(c)
+            output_path = os.path.join(d, "hist_{}.pdf".format(c))
+            self.save(output_path)
+
+
+def main():
+    description = 'Plot the contents of the spe HDF5 file'
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=Formatter)
+    parser.add_argument('-f', '--file', dest='input_path', action='store',
+                        help='path to the input spe HDF5 file')
+    parser.add_argument('-p', '--pixel', dest='plot_pixel', action='store',
+                        default=0, type=int,
+                        help='Pixel to plot the spectrum for')
+    args = parser.parse_args()
+
+    input_path = args.input_path
+    plot_pixel = args.plot_pixel
+
+    output_dir = os.path.join(os.path.splitext(input_path)[0], "spe")
+
+    store = pd.HDFStore(input_path)
+    df_pixel_coeff = store['coeff_pixel']
+    df_pixel_initial = store['initial_pixel']
+    df_pixel_array = store['array_pixel']
+    df_camera_coeff = store['coeff_camera']
+    df_camera_initial = store['initial_camera']
+    df_camera_array = store['array_camera']
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        mapping = store['mapping']
+        mapping.metadata = store.get_storer('mapping').attrs.metadata
+
+    metadata = store.get_storer('metadata').attrs.metadata
+
+    p_camera = SPECamera(mapping, output_dir)
+    p_camera.produce(df_pixel_coeff)
+    plt.close("all")
+
+    p_hist = SPEHist(output_dir)
+    p_hist.produce(df_pixel_coeff)
+    plt.close("all")
+
+    p_spectrum_pixel = SpectrumFitPlotter()
+    p_spectrum_pixel.plot_from_df_pixel(df_pixel_coeff, df_pixel_initial,
+                                        df_pixel_array, metadata, plot_pixel)
+    p_spectrum_pixel.save(os.path.join(output_dir, "spectrum_pixel.pdf"))
+
+    p_spectrum_camera = SpectrumFitPlotter()
+    p_spectrum_camera.plot_from_df_camera(df_camera_coeff, df_camera_initial,
+                                          df_camera_array, metadata)
+    p_spectrum_camera.save(os.path.join(output_dir, "spectrum_camera.pdf"))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/plot_spe.py
+++ b/scripts/plot_spe.py
@@ -50,10 +50,7 @@ class SPEHist(Plotter):
             mean = np.mean(values)
             std = np.std(values)
             label = "Mean = {:.3g}, Stddev = {:.3g}".format(mean, std)
-            try:
-                self.ax.hist(values, bins='fd', label=label)
-            except ValueError:
-                self.ax.hist(values, bins='doane', label=label)
+            self.ax.hist(values, bins='scott', label=label)
             self.add_legend()
             self.ax.set_title(c)
             output_path = os.path.join(d, "hist_{}.pdf".format(c))

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ setup(
         'matplotlib',
         'tqdm',
         'pandas>=0.21.0',
+        'iminuit',
+        'numba',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest', ],


### PR DESCRIPTION
- extract_spe reads N dl1 files to extract the charge and
simultaneously fit multiple illuminations
- The current fit formula is the one described in Gentile 2010. The SpectrumFitter class is designed such that other users can create their own fitting approach, and select it via the cmdline for extract_spe.py
- The low-level fit formula have been optimised, and have “Just In
Time” compilation applied from numba
- The loop over pixel is applied in a multiprocessing thread so they
are fitted in parallel by utilising all the cpu cores
- As a result, all the pixels for 3 different illuminations can be fit
within 7 minutes, with possible further optimisations