### PR TITLE
Fix bug in editing mapping metadata when converting

### DIFF
--- a/CHECLabPy/utils/mapping.py
+++ b/CHECLabPy/utils/mapping.py
@@ -97,7 +97,7 @@ def get_superpixel_mapping(mapping):
     df = df.groupby('superpixel').agg(f).reset_index()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
-        df.metadata = mapping.metadata
+        df.metadata = mapping.metadata.copy()
     df.metadata['n_rows'] = df['row'].max() + 1
     df.metadata['n_columns'] = df['col'].max() + 1
     df.metadata['size'] *= 2
@@ -125,7 +125,7 @@ def get_tm_mapping(mapping):
     df = df.groupby('slot').agg(f, as_index=False).reset_index()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
-        df.metadata = mapping.metadata
+        df.metadata = mapping.metadata.copy()
     df.metadata['n_rows'] = df['row'].max() + 1
     df.metadata['n_columns'] = df['col'].max() + 1
     df.metadata['size'] *= 8


### PR DESCRIPTION
A bug was found where using `get_superpixel_mapping` or `get_tm_mapping` would change the metadata of the original mapping object, which could result in camera images such as the following:

![image](https://user-images.githubusercontent.com/17825673/57649654-1a33f600-75c9-11e9-94aa-0b6f486dd74c.png)
